### PR TITLE
Meta sidebar is too meddlesome

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "__MSG_appName__",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "manifest_version": 2,
     "description": "__MSG_appDescription__",
     "short_name": "SE Block",

--- a/scripts/contentscript.js
+++ b/scripts/contentscript.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var classes = [
+                's-sidebarwidget',            // Block Overflow Blog and Hot Meta Posts
                 'community-bulletin',         // Block the community bulletin block.
                 'everyonelovesstackoverflow'  // Block the ads for Stack Overflow
                                               // Careers, despite the fact it got me


### PR DESCRIPTION
Dear Chris, thank you again for enabling five years of blissful productivity for me and your other lucky users. 

If I could persuade you to come once more into the breach to throw a new release into the Chrome Web Store that blocks the "Featured on Meta" and "Hot Meta Posts" in the sidebar with class s-sidebarwidget, we will all cheer in the most unironic, non-Meta way. 